### PR TITLE
upgrade the spring-boot-starter-parent to the latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.9.RELEASE</version>
+        <version>2.2.6.RELEASE</version>
         <relativePath />
     </parent>
     
@@ -33,7 +33,7 @@
         <!--        dependency properties-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <spring.security.oauth2.autoconfigure.version>2.1.9.RELEASE</spring.security.oauth2.autoconfigure.version>
+        <spring.security.oauth2.autoconfigure.version>2.2.6.RELEASE</spring.security.oauth2.autoconfigure.version>
         
         <!--        build properties-->
         <version.nexus-staging-maven-plugin>1.6.7</version.nexus-staging-maven-plugin>


### PR DESCRIPTION
This PR upgrades the the spring-boot-starter-parent to the latest version 2.2.6.RELEASE